### PR TITLE
Fixed strict standards errors, updated for custom taxonomies

### DIFF
--- a/main.php
+++ b/main.php
@@ -13,27 +13,26 @@ class Smarter_Navigation {
 
 	static $data = false;
 
-	function init() {
+	static function init() {
 		add_action( 'template_redirect', array( __CLASS__, 'manage_cookie' ) );
 		add_action( 'posts_clauses', array( __CLASS__, 'posts_clauses' ), 10, 2 );
 	}
 
-	public static function manage_cookie() {
+	static function manage_cookie() {
 		// Default conditions
 		$clear_condition = false;
 		$read_condition = is_singular();
 		$set_condition = !is_404();
-		$var = new self();
 
 		if ( apply_filters( 'smarter_nav_clear', $clear_condition ) )
-			$var->clear_cookie();
+			self::clear_cookie();
 		elseif ( apply_filters( 'smarter_nav_read', $read_condition ) )
-			$var->read_cookie();
+			self::read_cookie();
 		elseif ( apply_filters( 'smarter_nav_set', $set_condition ) )
-			$var->set_cookie();
+			self::set_cookie();
 	}
 
-	private function read_cookie() {
+	private static function read_cookie() {
 		if ( empty( $_COOKIE[self::NAME] ) )
 			return;
 
@@ -64,7 +63,7 @@ class Smarter_Navigation {
 			self::$data = false;
 	}
 
-	public function set_cookie( $data = '' ) {
+	public static function set_cookie( $data = '' ) {
 		$data = wp_parse_args( $data, array(
 			'query' => json_encode( $GLOBALS['wp_query']->query ),
 			'url' => ( is_ssl() ? 'https://' : 'http://' ) . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'],
@@ -75,7 +74,7 @@ class Smarter_Navigation {
 			setcookie( self::get_name( $key ), $value, 0, '/' );
 	}
 
-	public function clear_cookie() {
+	public static function clear_cookie() {
 		if ( empty( $_COOKIE[self::NAME] ) )
 			return;
 
@@ -83,11 +82,11 @@ class Smarter_Navigation {
 			setcookie( self::get_name( $key ), false, 0, '/' );
 	}
 
-	private function get_name( $key ) {
+	private static function get_name( $key ) {
 		return self::NAME . '[' . $key . ']';
 	}
 
-	static function adjacent_post( $format, $title_format, $previous, $fallback, $in_same_term, $excluded_terms, $taxonomy ) {
+	static function adjacent_post( $format, $title_format, $previous, $fallback, $in_same_cat, $excluded_categories ) {
 		$id = self::get_adjacent_id( $previous );
 
 		if ( !$id )
@@ -98,9 +97,9 @@ class Smarter_Navigation {
 				return false;
 
 			if ( $previous )
-				return previous_post_link( $format, $title_format, $in_same_term, $excluded_terms, $taxonomy );
+				return previous_post_link( $format, $title_format, $in_same_cat, $excluded_categories );
 			else
-				return next_post_link( $format, $title_format, $in_same_term, $excluded_terms, $taxonomy );
+				return next_post_link( $format, $title_format, $in_same_cat, $excluded_categories );
 		}
 
 		echo self::parse_format( $format, $title_format, get_permalink( $id ), get_the_title( $id ) );
@@ -238,8 +237,7 @@ class Smarter_Navigation {
 		return str_replace( '%link', $link, $link_format );
 	}
 }
-$var = new Smarter_Navigation();
-$var->init();
+Smarter_Navigation::init();
 
 include dirname( __FILE__ ) . '/template-tags.php';
 

--- a/main.php
+++ b/main.php
@@ -18,18 +18,19 @@ class Smarter_Navigation {
 		add_action( 'posts_clauses', array( __CLASS__, 'posts_clauses' ), 10, 2 );
 	}
 
-	function manage_cookie() {
+	public static function manage_cookie() {
 		// Default conditions
 		$clear_condition = false;
 		$read_condition = is_singular();
 		$set_condition = !is_404();
+		$var = new self();
 
 		if ( apply_filters( 'smarter_nav_clear', $clear_condition ) )
-			self::clear_cookie();
+			$var->clear_cookie();
 		elseif ( apply_filters( 'smarter_nav_read', $read_condition ) )
-			self::read_cookie();
+			$var->read_cookie();
 		elseif ( apply_filters( 'smarter_nav_set', $set_condition ) )
-			self::set_cookie();
+			$var->set_cookie();
 	}
 
 	private function read_cookie() {
@@ -86,7 +87,7 @@ class Smarter_Navigation {
 		return self::NAME . '[' . $key . ']';
 	}
 
-	static function adjacent_post( $format, $title_format, $previous, $fallback, $in_same_cat, $excluded_categories ) {
+	static function adjacent_post( $format, $title_format, $previous, $fallback, $in_same_term, $excluded_terms, $taxonomy ) {
 		$id = self::get_adjacent_id( $previous );
 
 		if ( !$id )
@@ -97,9 +98,9 @@ class Smarter_Navigation {
 				return false;
 
 			if ( $previous )
-				return previous_post_link( $format, $title_format, $in_same_cat, $excluded_categories );
+				return previous_post_link( $format, $title_format, $in_same_term, $excluded_terms, $taxonomy );
 			else
-				return next_post_link( $format, $title_format, $in_same_cat, $excluded_categories );
+				return next_post_link( $format, $title_format, $in_same_term, $excluded_terms, $taxonomy );
 		}
 
 		echo self::parse_format( $format, $title_format, get_permalink( $id ), get_the_title( $id ) );
@@ -237,7 +238,8 @@ class Smarter_Navigation {
 		return str_replace( '%link', $link, $link_format );
 	}
 }
-Smarter_Navigation::init();
+$var = new Smarter_Navigation();
+$var->init();
 
 include dirname( __FILE__ ) . '/template-tags.php';
 

--- a/template-tags.php
+++ b/template-tags.php
@@ -2,14 +2,14 @@
 
 // Replaces previous_post_link()
 // if $fallback is set to true, previous_post_link() will be called if there is no post found
-function previous_post_smart( $format = '&laquo; %link', $title = '%title', $fallback = true, $in_same_cat = true, $excluded_categories = '' ) {
-	return Smarter_Navigation::adjacent_post( $format, $title, true, $fallback, $in_same_cat, $excluded_categories );
+function previous_post_smart( $format = '&laquo; %link', $title = '%title', $fallback = true, $in_same_term = true, $excluded_terms = '', $taxonomy = 'category' ) {
+	return Smarter_Navigation::adjacent_post( $format, $title, true, $fallback, $in_same_term, $excluded_terms, $taxonomy );
 }
 
 // Replaces next_post_link()
 // if $fallback is set to true, next_post_link() will be called if there is no post found
-function next_post_smart( $format = '%link &raquo;', $title = '%title', $fallback = true, $in_same_cat = true, $excluded_categories = '' ) {
-	return Smarter_Navigation::adjacent_post( $format, $title, false, $fallback, $in_same_cat, $excluded_categories );
+function next_post_smart( $format = '%link &raquo;', $title = '%title', $fallback = true, $in_same_term = true, $excluded_terms = '', $taxonomy = 'category' ) {
+	return Smarter_Navigation::adjacent_post( $format, $title, false, $fallback, $in_same_term, $excluded_terms, $taxonomy );
 }
 
 // Returns the previous or next post id in the set
@@ -23,6 +23,7 @@ function referrer_link( $format = '%link', $title = '%title', $sep = '&raquo;', 
 }
 
 // Retrieve the category, based on the referrer URL. Useful if you have posts with multiple categories
+// This should be phased out and replaced with get_referrer_term
 function get_referrer_category() {
 	global $posts;
 
@@ -34,6 +35,24 @@ function get_referrer_category() {
 
 		if ( false !== strpos( $referrer_url, $cat_link ) )
 			return $cat;
+	}
+
+	return false;
+}
+
+// Retrieve the term, based on the referrer URL. Useful if you have posts with multiple terms
+// $taxonomy defaults to 'category'. Can be changed to custom taxonomy
+function get_referrer_term( $taxonomy = 'category' ) {
+	global $posts;
+
+	if ( ! $referrer_url = get_referrer_url( false ) )
+		return false;
+
+	foreach ( get_the_terms( $posts[0]->ID, $taxonomy ) as $term ) {
+		$term_link = get_term_link( $term->term_id, $taxonomy );
+
+		if ( false !== strpos( $referrer_url, $term_link ) )
+			return $term;
 	}
 
 	return false;

--- a/template-tags.php
+++ b/template-tags.php
@@ -22,24 +22,6 @@ function referrer_link( $format = '%link', $title = '%title', $sep = '&raquo;', 
 	echo Smarter_Navigation::referrer_link( $format, $title, $sep, $sepdirection );
 }
 
-// Retrieve the category, based on the referrer URL. Useful if you have posts with multiple categories
-// This should be phased out and replaced with get_referrer_term
-function get_referrer_category() {
-	global $posts;
-
-	if ( ! $referrer_url = get_referrer_url( false ) )
-		return false;
-
-	foreach ( get_the_category( $posts[0]->ID ) as $cat ) {
-		$cat_link = get_category_link( $cat->term_id );
-
-		if ( false !== strpos( $referrer_url, $cat_link ) )
-			return $cat;
-	}
-
-	return false;
-}
-
 // Retrieve the term, based on the referrer URL. Useful if you have posts with multiple terms
 // $taxonomy defaults to 'category'. Can be changed to custom taxonomy
 function get_referrer_term( $taxonomy = 'category' ) {
@@ -56,6 +38,18 @@ function get_referrer_term( $taxonomy = 'category' ) {
 	}
 
 	return false;
+}
+
+// Retrieve the category, based on the referrer URL. Useful if you have posts with multiple categories
+// Uses get_referrer_term()
+function get_referrer_category() {
+
+	$referrer = get_referrer_term( 'category' );
+
+	if ( is_wp_error( $referrer ) )
+		return false;
+
+	return $referrer;
 }
 
 // Retrieve the full referrer URL


### PR DESCRIPTION
I took a stab at fixing the strict standards warnings and updating the plugin to allow for custom taxonomies. It seems to be working correctly in my tests.

Thanks for the plugin!